### PR TITLE
Remove whitespace in translation keys of more than 2 characters.

### DIFF
--- a/src/TokenParser/TransTokenParser.php
+++ b/src/TokenParser/TransTokenParser.php
@@ -138,9 +138,11 @@ final class TransTokenParser extends AbstractTokenParser
         }
 
         // strip whitespace of more than 1 character
+        /** @var string $msg */
+        $msg = $body->getAttribute('data');
         $body->setAttribute(
             'data',
-            preg_replace('/\s{2,}/', ' ', $body->getAttribute('data'))
+            preg_replace('/\s{2,}/', ' ', $msg)
         );
 
         return new TransNode($body, $plural, $domain, $count, $vars, $notes, $context, $lineno, $this->getTag());

--- a/src/TokenParser/TransTokenParser.php
+++ b/src/TokenParser/TransTokenParser.php
@@ -137,6 +137,12 @@ final class TransTokenParser extends AbstractTokenParser
             [$body, $plural] = $this->parsePluralisation($body);
         }
 
+        // strip whitespace of more than 1 character
+        $body->setAttribute(
+            'data',
+            preg_replace('/\s{2,}/', ' ', $body->getAttribute('data'))
+        );
+
         return new TransNode($body, $plural, $domain, $count, $vars, $notes, $context, $lineno, $this->getTag());
     }
 
@@ -162,7 +168,7 @@ final class TransTokenParser extends AbstractTokenParser
      * @throws UnhandledPluralisationRuleException
      * @copyright Fabien Potencier <fabien@symfony.com>
      *
-     * @see       Symfony\Contracts\Translation\TranslatorInterface for more information on the format.
+     * @see       \Symfony\Contracts\Translation\TranslatorInterface for more information on the format.
      *
      * Copied from Symfony\Component\Translation\Dumper\PoFileDumper
      */

--- a/tests/integration/fixtures/tags/trans/strip_internal_whitespace.test
+++ b/tests/integration/fixtures/tags/trans/strip_internal_whitespace.test
@@ -1,0 +1,9 @@
+--TEST--
+strip internal whitespace from keys
+--TEMPLATE--
+        <p>{% trans %}If your translation key contains new lines due to syntax indentation we want
+        to be sure that they're all stripped out{% endtrans %}</p>
+--DATA--
+return []
+--EXPECT--
+<p>If your translation key contains new lines due to syntax indentation we want to be sure that they're all stripped out</p>


### PR DESCRIPTION
Remove whitespace of more than two characters from translation keys such that 

```
    My key to be
        translated
```

becomes

```
My key to be translated
```