### PR TITLE
Start testing lowest versions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -78,3 +78,4 @@ jobs:
           fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: matrix.php-versions == '8.4'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,10 +16,16 @@ jobs:
         php-versions: [ '8.2', '8.3' ]
         phpunit-versions: ['11.0']
         psalm-versions: ['6.0']
+        dependency-versions: ['']
         include:
           - php-versions: '8.1'
             phpunit-versions: '10.0'
             psalm-versions: '5.0'
+            dependency-versions: ['']
+          - php-versions: '8.1'
+            phpunit-versions: '10.0'
+            psalm-versions: '5.0'
+            dependency-versions: ['--prefer-lowest']
 
     steps:
       - name: Setup PHP with PECL extension
@@ -51,7 +57,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
-        run: composer install --prefer-dist --no-progress
+        run: composer install --prefer-dist --no-progress ${{ matrix.dependency-versions }}
 
       - name: Install tools
         run: phive --no-progress install --trust-gpg-keys 4AA394086372C20A,12CE0F1D262429A5,97B02DD8E5071466 phpunit@^${{ matrix.phpunit-versions }} psalm@^${{ matrix.psalm-versions }} phpcs

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -7,13 +7,13 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  test-lint-and-analyse:
 
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        php-versions: [ '8.2', '8.3' ]
+        php-versions: [ '8.2', '8.3', '8.4' ]
         phpunit-versions: ['11.0']
         psalm-versions: ['6.0']
         dependency-versions: ['']

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -21,11 +21,11 @@ jobs:
           - php-versions: '8.1'
             phpunit-versions: '10.0'
             psalm-versions: '5.0'
-            dependency-versions: ['']
+            dependency-versions: ''
           - php-versions: '8.1'
             phpunit-versions: '10.0'
             psalm-versions: '5.0'
-            dependency-versions: ['--prefer-lowest']
+            dependency-versions: '--prefer-lowest'
 
     steps:
       - name: Setup PHP with PECL extension

--- a/composer.json
+++ b/composer.json
@@ -10,16 +10,16 @@
     }
   ],
   "require": {
-    "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
+    "php": ">=8.1 <8.5",
     "ext-gettext": "*",
     "twig/twig": "^v3.21",
     "symfony/finder": "^4.0 || ^5.0",
     "gettext/gettext": "^5.5",
     "gettext/translator": "^1.0",
-    "nikic/php-parser": "^4.9 || ^5.6"
+    "nikic/php-parser": "^4.18 || ^5.6"
   },
   "require-dev": {
-    "mikey179/vfsstream": "^v1.6"
+    "mikey179/vfsstream": "^v1.6.10"
   },
   "autoload": {
     "psr-4": {

--- a/src/AbstractFileExtractor.php
+++ b/src/AbstractFileExtractor.php
@@ -22,9 +22,9 @@ abstract class AbstractFileExtractor implements ExtractorInterface
      * Pulls a list of php file info objects from a supplied filename, iterable list of filenames or directory name
      *
      * @param string $resource
-     * @return array<SplFileInfo>|Finder
+     * @return SplFileInfo[]|iterable<\Symfony\Component\Finder\SplFileInfo>
      */
-    protected function extractFiles(string $resource): array|Finder
+    protected function extractFiles(string $resource): iterable
     {
         if (is_file($resource)) {
             $files = $this->canBeExtracted($resource) ? [$this->toSplFileInfo($resource)] : [];
@@ -51,7 +51,11 @@ abstract class AbstractFileExtractor implements ExtractorInterface
         return $this->getExtension() === pathinfo($file, PATHINFO_EXTENSION);
     }
 
-    protected function extractFromDirectory(string $directory): Finder
+    /**
+     * @param string $directory
+     * @return iterable<\Symfony\Component\Finder\SplFileInfo>
+     */
+    protected function extractFromDirectory(string $directory): iterable
     {
         $finder = new Finder();
 


### PR DESCRIPTION
I realised after pushing the last update that I've not been testing against the lowest versions of the PHP dependencies. 

On doing so I found that some things weren't working quite right and so had to bump some things. Additionally psalm started complaining about some of the SPLFile stuff so I made the docblocks a little more helpful.